### PR TITLE
fix: refactor to improve readability of main_page function

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
       "requires": {
         "follow-redirects": "^1.10.0"
       }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/gary-kim/saspes#readme",
   "dependencies": {
-    "axios": "^0.20.0"
+    "axios": "^0.21.0"
   }
 }

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -27,6 +27,7 @@
 import Assignment from "./models/Assignment";
 import Course from './models/Course';
 import browser from 'webextension-polyfill';
+
 const getKeyRange = require('get-key-range');
 
 const grade_gpa = {

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -76,44 +76,12 @@ function main () {
 }
 
 function main_page () {
-    let student_name = getStudentName();
-    let { sem1_col, sem2_col } = getSemesterCols();
-    let second_semester = isSecondSemester();
-    const courses = [];
-    const $grade_rows = $('#quickLookup table.grid').find('tr');
+    const student_name = getStudentName();
+    const { sem1_col, sem2_col } = getSemesterCols();
+    const second_semester = isSecondSemester();
+    const current_term = getCurrentTerm();
+    const courses = getCourses(second_semester);
 
-    for (let i = 0; i < $grade_rows.length; i++) {
-        let $course;
-        if (second_semester) {
-            const $cells = $grade_rows.eq(i).find('td');
-            $course = $cells.eq(sem2_col).find('a[href^="scores.html"]');
-            const $first_grade = $cells.eq(sem1_col).find('a[href^="scores.html"]');
-            if ($first_grade.length === 1) {
-                if (gradeToGPA($first_grade.text()) !== -1) {
-                    new (Vue.extend(ClassGrade))({
-                        propsData: {
-                            course: new Course("", `https://powerschool.sas.edu.sg/guardian/${$first_grade.attr('href')}`, $first_grade.text()),
-                            showMissing: false,
-                        },
-                    }).$mount($first_grade.get(0));
-                }
-            }
-        } else {
-            $course = $grade_rows.eq(i).find('td a[href^="scores.html"]').eq(0);
-        }
-        if ($course.length === 1) {
-            const temp = $course.parents().eq(1).children("td[align=left]").text().match(".*(?=Details)")[0];
-            courses.push(new Course(temp.trim(), `https://powerschool.sas.edu.sg/guardian/${$course.attr('href')}`, $course.text()));
-            if (gradeToGPA($course.text()) !== -1) {
-                new (Vue.extend(ClassGrade))({
-                    propsData: {
-                        course: courses[courses.length - 1],
-                    },
-                }).$mount($course.get(0));
-            }
-        }
-    }
-    let current_term = getCurrentTerm();
     showCurrentGPA(second_semester, courses);
 
     if (second_semester) {
@@ -252,6 +220,50 @@ function getCurrentTerm () {
     }
 
     return current_term;
+}
+
+/**
+ * Returns an array of the current courses of the user and creates Vue objects for the courses.
+ * @param second_semester If the current semester is the second semester
+ * @returns {Course[]} array of Course objects representing the Courses of the user
+ */
+function getCourses(second_semester) {
+    const $grade_rows = $('#quickLookup table.grid').find('tr');
+    const courses = [];
+
+    for (let i = 0; i < $grade_rows.length; i++) {
+        let $course;
+        if (second_semester) {
+            const $cells = $grade_rows.eq(i).find('td');
+            $course = $cells.eq(sem2_col).find('a[href^="scores.html"]');
+            const $first_grade = $cells.eq(sem1_col).find('a[href^="scores.html"]');
+            if ($first_grade.length === 1) {
+                if (gradeToGPA($first_grade.text()) !== -1) {
+                    new (Vue.extend(ClassGrade))({
+                        propsData: {
+                            course: new Course("", `https://powerschool.sas.edu.sg/guardian/${$first_grade.attr('href')}`, $first_grade.text()),
+                            showMissing: false,
+                        },
+                    }).$mount($first_grade.get(0));
+                }
+            }
+        } else {
+            $course = $grade_rows.eq(i).find('td a[href^="scores.html"]').eq(0);
+        }
+        if ($course.length === 1) {
+            const temp = $course.parents().eq(1).children("td[align=left]").text().match(".*(?=Details)")[0];
+            courses.push(new Course(temp.trim(), `https://powerschool.sas.edu.sg/guardian/${$course.attr('href')}`, $course.text()));
+            if (gradeToGPA($course.text()) !== -1) {
+                new (Vue.extend(ClassGrade))({
+                    propsData: {
+                        course: courses[courses.length - 1],
+                    },
+                }).$mount($course.get(0));
+            }
+        }
+    }
+
+    return courses;
 }
 
 /**

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -109,14 +109,10 @@ function class_page () {
         return;
     }
     document.querySelector("table.linkDescList").append(html2node(`<tr><td><strong>Final Percent: </strong></td><td>` + number.toFixed(2) + ` <div class="tooltip saspes">&#9432;<span class="tooltiptext saspes">85: A+ | 75: A <br />65: B+ | 55: B <br />45: C+ | 35: C <br/>25: D+ | 15: D</span></div></td></tr>`));
-
-    document.querySelector('div.box-round').insertAdjacentHTML('afterend', `<div id="saspes-hypo-assignment"></div>`);
-    new (Vue.extend(HypoAssignment))({
-        propsData: {
-            currentFP: number,
-        },
-    }).$mount('#saspes-hypo-assignment');
+    
+    addHypoAssignment();
 }
+
 function login_page () {
     $('<div id="saspes-info"></div>').insertAfter('div#content');
     browser.storage.local.get({ showExtensionInfo: true }).then(result => {
@@ -302,7 +298,7 @@ function getFirstSemCourses () {
 
 /**
  * Adds the hypothetical grade calculator.
- * @param {courses} The courses of the student
+ * @param courses The courses of the student
  */
 function addHypoGradeCalc (courses) {
     const HypoGradesDiv = document.createElement('div');
@@ -314,4 +310,17 @@ function addHypoGradeCalc (courses) {
             initialCourses: courses,
         },
     }).$mount(".hypo-grade-div-fixed");
+}
+
+/**
+ * Add a hypothetical assignment calculator widget.
+ * @param number The current final percent of the student.
+ */
+function addHypoAssignment (number) {
+    document.querySelector('div.box-round').insertAdjacentHTML('afterend', `<div id="saspes-hypo-assignment"></div>`);
+    new (Vue.extend(HypoAssignment))({
+        propsData: {
+            currentFP: number,
+        },
+    }).$mount('#saspes-hypo-assignment');
 }

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -99,16 +99,7 @@ function main_page () {
     }).$mount("#cumulative-gpa");
 
     saveGradesLocally(student_name, courses);
-    // Hypo Grade Calculator
-    const HypoGradesDiv = document.createElement('div');
-    HypoGradesDiv.classList.add("hypo-grade-div-fixed");
-    HypoGradesDiv.id = "saspes-hypo-grades";
-    document.body.appendChild(HypoGradesDiv);
-    new (Vue.extend(HypoGrades))({
-        propsData: {
-            initialCourses: courses,
-        },
-    }).$mount(".hypo-grade-div-fixed");
+    addHypoGradeCalc(courses);
 }
 
 function class_page () {
@@ -307,4 +298,20 @@ function getFirstSemCourses () {
             resolve(response);
         });
     });
+}
+
+/**
+ * Adds the hypothetical grade calculator.
+ * @param {courses} The courses of the student
+ */
+function addHypoGradeCalc (courses) {
+    const HypoGradesDiv = document.createElement('div');
+    HypoGradesDiv.classList.add("hypo-grade-div-fixed");
+    HypoGradesDiv.id = "saspes-hypo-grades";
+    document.body.appendChild(HypoGradesDiv);
+    new (Vue.extend(HypoGrades))({
+        propsData: {
+            initialCourses: courses,
+        },
+    }).$mount(".hypo-grade-div-fixed");
 }

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -81,8 +81,6 @@ function main_page () {
     let second_semester = isSecondSemester();
     const courses = [];
     const $grade_rows = $('#quickLookup table.grid').find('tr');
-    let current_term = "";
-    let attendance_href = "";
 
     for (let i = 0; i < $grade_rows.length; i++) {
         let $course;
@@ -115,9 +113,7 @@ function main_page () {
             }
         }
     }
-    if ((attendance_href = $grade_rows.eq($grade_rows.length - 1)?.find('a[href*="attendancedates"]')?.[0]?.href)) { // Check that attendance_href exists and if it does, run the next line.
-        current_term = new URL(attendance_href).searchParams.get("term");
-    }
+    let current_term = getCurrentTerm();
     showCurrentGPA(second_semester, courses);
 
     if (second_semester) {
@@ -241,6 +237,21 @@ function isSecondSemester (sem2_col) {
  */
 function showCurrentGPA (second_semester, courses) {
     $("table[border='0'][cellpadding='3'][cellspacing='1'][width='100%']").prepend(`<tr><td align="center">Current Semester GPA (${second_semester ? 'S2' : 'S1'}): ${calculate_gpa(courses)}</td></tr>`);
+}
+
+/**
+ * Returns the current semester by parsing HTML.
+ * @return {string} representing the current semester
+ */
+function getCurrentTerm () {
+    const $grade_rows = $('#quickLookup table.grid').find('tr');
+    let attendance_href = "";
+    let current_term = "";
+    if ((attendance_href = $grade_rows.eq($grade_rows.length - 1)?.find('a[href*="attendancedates"]')?.[0]?.href)) { // Check that attendance_href exists and if it does, run the next line.
+        current_term = new URL(attendance_href).searchParams.get("term");
+    }
+
+    return current_term;
 }
 
 /**

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -111,7 +111,7 @@ function class_page () {
     }
     document.querySelector("table.linkDescList").append(html2node(`<tr><td><strong>Final Percent: </strong></td><td>` + number.toFixed(2) + ` <div class="tooltip saspes">&#9432;<span class="tooltiptext saspes">85: A+ | 75: A <br />65: B+ | 55: B <br />45: C+ | 35: C <br/>25: D+ | 15: D</span></div></td></tr>`));
 
-    addHypoAssignment();
+    addHypoAssignment(number);
 }
 
 function login_page () {

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -290,13 +290,8 @@ function showFirstSemGPA () {
  * Get the first semester courses and grades HTML.
  * @returns {Promise} the html from the first semester course and grades page
  */
-function getFirstSemCourses () {
-    return new Promise((resolve, reject) => {
-        fetch("https://powerschool.sas.edu.sg/guardian/termgrades.html")
-            .then(response => {
-                resolve(response);
-            });
-    });
+async function getFirstSemCourses () {
+    return await (await fetch("https://powerschool.sas.edu.sg/guardian/termgrades.html")).text();
 }
 
 /**

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -29,12 +29,13 @@
 import $ from 'jquery';
 const browser = require('webextension-polyfill');
 
-import { 
+import {
     calculate_gpa, 
     extractFinalPercent, 
     gradeToGPA, 
     analytics_message, 
-    saveGradesLocally } from './helpers';
+    saveGradesLocally 
+} from './helpers';
 
 // Vue Components
 import Vue from 'vue';
@@ -80,7 +81,7 @@ function main_page () {
     const { sem1_col, sem2_col } = getSemesterCols();
     const second_semester = isSecondSemester();
     const current_term = getCurrentTerm();
-    const courses = getCourses(second_semester);
+    const courses = getCourses(second_semester, sem1_col, sem2_col);
 
     showCurrentGPA(second_semester, courses);
 
@@ -212,9 +213,11 @@ function getCurrentTerm () {
 /**
  * Returns an array of the current courses of the user and creates Vue objects for the courses.
  * @param second_semester If the current semester is the second semester
+ * @param sem1_col The column of the first semester
+ * @param sem2_col The column of the second semester
  * @returns {Course[]} array of Course objects representing the Courses of the user
  */
-function getCourses(second_semester) {
+function getCourses (second_semester, sem1_col, sem2_col) {
     const $grade_rows = $('#quickLookup table.grid').find('tr');
     const courses = [];
 

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -30,11 +30,11 @@ import $ from 'jquery';
 const browser = require('webextension-polyfill');
 
 import {
-    calculate_gpa, 
-    extractFinalPercent, 
-    gradeToGPA, 
-    analytics_message, 
-    saveGradesLocally 
+    calculate_gpa,
+    extractFinalPercent,
+    gradeToGPA,
+    analytics_message,
+    saveGradesLocally,
 } from './helpers';
 
 // Vue Components
@@ -110,7 +110,7 @@ function class_page () {
         return;
     }
     document.querySelector("table.linkDescList").append(html2node(`<tr><td><strong>Final Percent: </strong></td><td>` + number.toFixed(2) + ` <div class="tooltip saspes">&#9432;<span class="tooltiptext saspes">85: A+ | 75: A <br />65: B+ | 55: B <br />45: C+ | 35: C <br/>25: D+ | 15: D</span></div></td></tr>`));
-    
+
     addHypoAssignment();
 }
 
@@ -262,28 +262,28 @@ function getCourses (second_semester, sem1_col, sem2_col) {
 function showFirstSemGPA () {
     const courses_first_semester = [];
     getFirstSemCourses()
-    .then((data) => {
-        const el = document.createElement("html");
-        let element_list = [];
-        el.innerHTML = data;
-        element_list = el.getElementsByClassName("box-round")[0].getElementsByTagName("table")[0];
-        element_list = element_list.getElementsByTagName("tbody")[0].getElementsByTagName("tr");
-        if (element_list.length > 2) {
-            for (let i = 2; i < element_list.length; i++) {
-                const $prev_course = element_list[i];
-                if ($prev_course?.innerText?.trim() === "S2") {
-                    break;
+        .then((data) => {
+            const el = document.createElement("html");
+            let element_list = [];
+            el.innerHTML = data;
+            element_list = el.getElementsByClassName("box-round")[0].getElementsByTagName("table")[0];
+            element_list = element_list.getElementsByTagName("tbody")[0].getElementsByTagName("tr");
+            if (element_list.length > 2) {
+                for (let i = 2; i < element_list.length; i++) {
+                    const $prev_course = element_list[i];
+                    if ($prev_course?.innerText?.trim() === "S2") {
+                        break;
+                    }
+                    if ($prev_course?.getElementsByTagName("td").length > 1) {
+                        courses_first_semester.push(new Course($prev_course.getElementsByTagName("td")[0].textContent.trim(),
+                            $prev_course.getElementsByTagName("td")[2].getElementsByTagName("a")[0].href,
+                            $prev_course.getElementsByTagName("td")[1].textContent.trim(),
+                        ));
+                    }
                 }
-                if ($prev_course?.getElementsByTagName("td").length > 1) {
-                    courses_first_semester.push(new Course($prev_course.getElementsByTagName("td")[0].textContent.trim(),
-                        $prev_course.getElementsByTagName("td")[2].getElementsByTagName("a")[0].href,
-                        $prev_course.getElementsByTagName("td")[1].textContent.trim(),
-                    ));
-                }
+                $("table[border='0'][cellpadding='3'][cellspacing='1'][width='100%']").prepend(`<tr><td align="center">Last Semester GPA (S1): ${calculate_gpa(courses_first_semester)}</td></tr>`);
             }
-            $("table[border='0'][cellpadding='3'][cellspacing='1'][width='100%']").prepend(`<tr><td align="center">Last Semester GPA (S1): ${calculate_gpa(courses_first_semester)}</td></tr>`);
-        }
-    });
+        });
 }
 
 /**
@@ -293,9 +293,9 @@ function showFirstSemGPA () {
 function getFirstSemCourses () {
     return new Promise((resolve, reject) => {
         fetch("https://powerschool.sas.edu.sg/guardian/termgrades.html")
-        .then(response => {
-            resolve(response);
-        });
+            .then(response => {
+                resolve(response);
+            });
     });
 }
 


### PR DESCRIPTION
When initially browsing through the codebase, it was very difficult to grasp what all the lines of code were doing. I took the time to move verbose blocks of code into functions whose names hopefully describe what they were doing. By representing these blocks with single-line functions, it makes it easier to understand what the `main_page` function is trying to do, and thus less intimidating to contribute to.

I additionally rebased my commits to make their subject lines more consistent with one another, and in doing so, accidentally made myself a contributor to the `9eceaf4` commit, so ignore that. My commit messages further detail my line of reasoning for specific chunks in the code.