### PR TITLE
refactor: change browser.storage.local structure

### DIFF
--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -214,8 +214,23 @@ async function getSavedGrades (username) {
  * @param {Course[]} courses list of course objects to save
  */
 async function saveGradesLocally (username, courses) {
-    const data = {};
-    const user_data = {};
+    const data = await getLocalConfig() || {};
+
+    if (data.opted_in === undefined) {
+        data.opted_in = {
+            value: true,
+            changed: false,
+        };
+    }
+
+    if (data.showExtensionInfo === undefined) {
+        data.showExtensionInfo = {
+            value: true,
+            changed: false,
+        };
+    }
+
+    const user_data = await browser.storage.local.get("user_data") || {};
     const course_list = [];
     for (let i = 0; i < courses.length; i++) {
         course_list.push(courses[i].toObject());
@@ -223,17 +238,19 @@ async function saveGradesLocally (username, courses) {
     user_data["USERDATA_" + username] = { "courses": course_list };
 
     data.user_data = user_data;
-    data.opted_in = {
-        value: true,
-        changed: false,
-    };
-    data.showExtensionInfo = {
-        value: true,
-        changed: false,
-    };
     data.most_recent_user = username;
 
     browser.storage.local.set(data);
+}
+
+/**
+ * Retrieves the config from the browser's local storage
+ * @async
+ * @returns {Config} an object representing the user's config from the browser's local storage
+ */
+async function getLocalConfig () {
+    const data = await browser.storage.local.get(null);
+    return data;
 }
 
 /**

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -186,14 +186,24 @@ function assignments (node) {
  */
 async function getSavedGrades (username) {
     const courses = [];
-    const output = await browser.storage.local.get("USERDATA_" + username);
-    if (output !== undefined && output["USERDATA_" + username] !== undefined) {
-        const course_list = output["USERDATA_" + username].courses || [];
-        for (let i = 0; i < course_list.length; i++) {
-            const course = course_list[i];
-            courses.push(new Course(course.name, course.link, course.grade, course.finalPercent, course.assignments));
+    const user_data = (await browser.storage.local.get("user_data")).user_data;
+    if (user_data !== undefined) {
+        const user = user_data["USERDATA_" + username];
+        if (user !== undefined) {
+            const course_list = user.courses || [];
+            for (let ind = 0; ind < course_list.length; ind++) {
+                const course = course_list[ind];
+                courses.push(new Course(
+                    course.name,
+                    course.link,
+                    course.grade,
+                    course.finalPercent,
+                    course.assignments,
+                ));
+            }
+
+            return courses;
         }
-        return courses;
     }
 }
 
@@ -204,14 +214,20 @@ async function getSavedGrades (username) {
  * @param {Course[]} courses list of course objects to save
  */
 async function saveGradesLocally (username, courses) {
+    const data = {};
     const user_data = {};
     const course_list = [];
     for (let i = 0; i < courses.length; i++) {
         course_list.push(courses[i].toObject());
     }
     user_data["USERDATA_" + username] = { "courses": course_list };
-    user_data.most_recent_user = username;
-    browser.storage.local.set(user_data);
+
+    data.user_data = user_data;
+    data.opted_in = true;
+    data.most_recent_user = username;
+    data.showExtensionInfo = true;
+
+    browser.storage.local.set(data);
 }
 
 /**

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -223,9 +223,15 @@ async function saveGradesLocally (username, courses) {
     user_data["USERDATA_" + username] = { "courses": course_list };
 
     data.user_data = user_data;
-    data.opted_in = true;
+    data.opted_in = {
+        value: true,
+        changed: false,
+    };
+    data.showExtensionInfo = {
+        value: true,
+        changed: false,
+    };
     data.most_recent_user = username;
-    data.showExtensionInfo = true;
 
     browser.storage.local.set(data);
 }

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -122,7 +122,7 @@ async function login_page () {
     browser.storage.local.get("showExtensionInfo").then(output => {
         new (Vue.extend(ExtensionInfo))({
             data: {
-                showInfo: output.showExtensionInfo,
+                showInfo: output.showExtensionInfo.value,
             },
         }).$mount('#saspes-info');
     });
@@ -132,7 +132,7 @@ async function login_page () {
     LastGradesDiv.id = "saspes-last-grades";
     document.body.appendChild(LastGradesDiv);
 
-    if ((await browser.storage.local.get("opted_in")).opted_in) {
+    if ((await browser.storage.local.get("opted_in")).opted_in.value) {
         (browser.storage.local.get("most_recent_user")).then(output => {
             const most_recent_user = output.most_recent_user;
             if (most_recent_user !== undefined) {

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -119,25 +119,28 @@ function class_page () {
 
 async function login_page () {
     $('<div id="saspes-info"></div>').insertAfter('div#content');
-    browser.storage.local.get({ showExtensionInfo: true }).then(result => {
+    browser.storage.local.get("showExtensionInfo").then(output => {
         new (Vue.extend(ExtensionInfo))({
             data: {
-                showInfo: result.showExtensionInfo,
+                showInfo: output.showExtensionInfo,
             },
         }).$mount('#saspes-info');
     });
+
     const LastGradesDiv = document.createElement('div');
     LastGradesDiv.classList.add("last-grade-div-fixed");
     LastGradesDiv.id = "saspes-last-grades";
     document.body.appendChild(LastGradesDiv);
-    if ((await browser.storage.local.get({ save_last_grades: true })).save_last_grades) {
+
+    if ((await browser.storage.local.get("opted_in")).opted_in) {
         (browser.storage.local.get("most_recent_user")).then(output => {
-            if (output.most_recent_user !== undefined) {
+            const most_recent_user = output.most_recent_user;
+            if (most_recent_user !== undefined) {
                 (async () => {
-                    const courses = await getSavedGrades(output.most_recent_user);
+                    const courses = await getSavedGrades(most_recent_user);
                     new (Vue.extend(LastSeenGrades))({
                         propsData: {
-                            username: output.most_recent_user,
+                            username: most_recent_user,
                             initialCourses: courses,
                         },
                     }).$mount(".last-grade-div-fixed");


### PR DESCRIPTION
This refactor aims to make the data a bit more organised so I can later add the opt-out by default feature to displaying last seen grades without having a headache.

`browser.storage.local`'s initial structure looked something like this:

```json
{
    "user_data": {
        "most_recent_user": "name",
        "user": {
            "stuff": "goes here",
        }
    }
}
```

I altered it to look like this:

```json
{
    "data": {
        "opted_in": true,
        "showExtensionInfo": true,
        "most_recent_user": "name",
        "user_data": {
            "user": {
                "stuff": "goes here",
            }
        }
    }
}
```

Originally, `user_data` was the main data stored. I changed it to be a single part of the data that is stored. `most_recent_user` was inside of `user_data`, but I felt it didn't fit, so I moved it outside into `data`.

`opted_in` is the variable name I replaced for `save_last_grades`. `save_last_grades` was originally accessed/created by doing:
```js
browser.storage.local.get({"save_last_grades": true});
```

When searching through the local storage by supplying an object as the function argument, the fields in the object are used as default values. So, despite `save_last_grades` not actually being a part of the stored data, it was returned as part of the data. Changing this to search regularly (with the name of the object as the key in the storage) fixes this, as well as adding the field in the instantiation of `data`.

"showExtensionInfo" is some "legacy" (I'm using this tentatively) stuff Gary added that I'm too lazy to figure out.

Edit: removed commit formatting