### PR TITLE
fix: ignore queries for home page

### DIFF
--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -74,7 +74,7 @@ function main () {
     });
 
     const page_url = window.location.href.split('#')[0];
-    if (page_url === "https://powerschool.sas.edu.sg/guardian/home.html" || page_url === "https://powerschool.sas.edu.sg/guardian/homeHS.html") {
+    if (page_url.match("https://powerschool.sas.edu.sg/guardian/home") != null) {
         main_page();
     } else if (page_url.match("https://powerschool.sas.edu.sg/guardian/scores") != null) {
         class_page();


### PR DESCRIPTION
When pressing _Grades and Attendance_ from the _Standards Grades_ tab power school adds the `schoolid=400` query to the URL. This leads to the extension not running the `main_page()` function as is the indented action.