### PR TITLE
Fix percentages not showing and cumulative GPA double including finished semester

### DIFF
--- a/src/js/components/CumulativeGPA.vue
+++ b/src/js/components/CumulativeGPA.vue
@@ -170,16 +170,18 @@ export default {
                                     semester.innerHTML = data2;
                                     element_list = semester.getElementsByClassName("box-round")[0].getElementsByTagName("table")[0];
                                     element_list = element_list.getElementsByTagName("tbody")[0].getElementsByTagName("tr");
-                                    for (let t = 2; t < element_list.length; t++) {
+                                    for (let t = 0; t < element_list.length; t++) {
                                         if (element_list[t].innerText.trim() === ("S2")) {
-                                            most_recent_term = "S2";
                                             all_courses.push(courses);
                                             if (i === 0) {
+                                                most_recent_term = "S2";
                                                 current_term_grades.push(courses);
                                             }
                                             courses = [];
                                         } else if (element_list[t].innerText.trim() === ("S1")) {
-                                            most_recent_term = "S1";
+                                            if (i === 0) {
+                                                most_recent_term = "S1";
+                                            }
                                         }
                                         if (element_list[t].getElementsByTagName("th").length > 0) {
                                             continue;

--- a/src/js/components/GradeTable.vue
+++ b/src/js/components/GradeTable.vue
@@ -23,7 +23,7 @@
  -->
 
 <template>
-    <div>
+    <div style="display: none;" id="gt-container">
         <table
             border="0"
             cellpadding="0"

--- a/src/js/components/GradeTable.vue
+++ b/src/js/components/GradeTable.vue
@@ -123,7 +123,7 @@ export default {
     }),
     methods: {
         addAssignment () {
-            this.assignments.push(new ClassAssignment(this.assignments[this.assignments.length - 1].id + 1, "today", this.categories[0], "New Assignment", false, false, false, false, false, "--/9", "B", true));
+            this.assignments.push(new ClassAssignment(this.assignments[this.assignments.length - 1].id + 1, "Today", this.categories[0], "New Assignment", false, false, false, false, false, false, false, "--/9", "B", true));
         },
         calculateGrades (catmap) {
             try {

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -150,7 +150,8 @@ function extractFinalPercent (html) {
         let current_string = html.match(/(?=document\.write).*/g)[1];
         current_string = /\[.*\]/g.exec(current_string)[0].slice(1, -1);
         const temp = current_string.split(";");
-        number = Math.max(isNaN(temp[temp.length - 2]) || temp[temp.length - 2] ? parseFloat(temp[temp.length - 2]) : -Infinity, isNaN(temp[temp.length - 1]) || temp[temp.length - 1] ? parseFloat(temp[temp.length - 1]) : -Infinity);
+        console.log(temp);
+        number = Math.max(isNaN(temp[temp.length - 2]) ? -Infinity : parseFloat(temp[temp.length - 2]), isNaN(temp[temp.length - 1]) ? -Infinity : parseFloat(temp[temp.length - 1]));
     } catch (e) {
         return;
     }
@@ -244,13 +245,12 @@ function assignmentsFromNode (node) {
 
 /**
  * Return Assignment instances for the given class page.
- * @param {String} student_id student id for the current user
- * @param {String} sectino_id section id for the course being requested
- * @param {String} start_date start date in YYYY-MM-DD format
- * @param {String} end_date end date in YYYY-MM-DD format
+ * @param {String} studentId student id for the current user
+ * @param {String} sectionId section id for the course being requested
+ * @param {String} currentSemester the current semester (either S1 or S2)
  * @returns {Assignment[]} Assignments in this course
  */
-function assignmentsFromAPI (studentId, sectionId, startDate, endDate) {
+function assignmentsFromAPI (studentId, sectionId, currentSemester) {
     const assignmentList = [];
     try {
         fetch('https://powerschool.sas.edu.sg/ws/xte/assignment/lookup', {
@@ -261,8 +261,7 @@ function assignmentsFromAPI (studentId, sectionId, startDate, endDate) {
             body: JSON.stringify({
                 "student_ids": [studentId],
                 "section_ids": [sectionId],
-                "start_date": startDate,
-                "end_date": endDate,
+                "store_codes": [currentSemester],
             }),
             credentials: "same-origin",
         }).then(response => response.json()).then(response => {

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -150,7 +150,6 @@ function extractFinalPercent (html) {
         let current_string = html.match(/(?=document\.write).*/g)[1];
         current_string = /\[.*\]/g.exec(current_string)[0].slice(1, -1);
         const temp = current_string.split(";");
-        console.log(temp);
         number = Math.max(isNaN(temp[temp.length - 2]) ? -Infinity : parseFloat(temp[temp.length - 2]), isNaN(temp[temp.length - 1]) ? -Infinity : parseFloat(temp[temp.length - 1]));
     } catch (e) {
         return;

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -128,27 +128,27 @@ async function class_page () {
     document.getElementById('saspes-hypo-assignment').style.display = "none";
     document.getElementById('saspes-categories').style.display = "none";
     const gtContainer = document.createElement("div");
-    document.getElementById("scoreTable").parentElement.appendChild(gtContainer);
+    document.getElementById('scoreTable').parentElement.appendChild(gtContainer);
     gt.$mount(gtContainer);
     document.getElementById('hypo-select').onchange = function () {
         const opt = document.getElementById('hypo-select').value;
         if (opt === "none") {
             document.getElementById('saspes-hypo-assignment').style.display = "none";
             document.getElementById('saspes-categories').style.display = "none";
-            document.getElementById("gt-container").style.display = "none";
-            document.getElementById("scoreTable").style.display = "block";
+            document.getElementById('gt-container').style.display = "none";
+            document.getElementById('scoreTable').style.display = "block";
             gt.setCategoryWeighting(false);
         } else if (opt === "single") {
             document.getElementById('saspes-hypo-assignment').style.display = "block";
             document.getElementById('saspes-categories').style.display = "none";
-            document.getElementById("gt-container").style.display = "none";
-            document.getElementById("scoreTable").style.display = "block";
+            document.getElementById('gt-container').style.display = "none";
+            document.getElementById('scoreTable').style.display = "block";
             gt.setCategoryWeighting(false);
         } else {
             document.getElementById('saspes-hypo-assignment').style.display = "none";
             document.getElementById('saspes-categories').style.display = "block";
-            document.getElementById("gt-container").style.display = "block";
-            document.getElementById("scoreTable").style.display = "none";
+            document.getElementById('gt-container').style.display = "block";
+            document.getElementById('scoreTable').style.display = "none";
             gt.setCategoryWeighting(true);
         }
     };

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -127,23 +127,28 @@ async function class_page () {
     gt.setCategoryWeighting(false);
     document.getElementById('saspes-hypo-assignment').style.display = "none";
     document.getElementById('saspes-categories').style.display = "none";
+    const gtContainer = document.createElement("div");
+    document.getElementById("scoreTable").parentElement.appendChild(gtContainer);
+    gt.$mount(gtContainer);
     document.getElementById('hypo-select').onchange = function () {
         const opt = document.getElementById('hypo-select').value;
         if (opt === "none") {
             document.getElementById('saspes-hypo-assignment').style.display = "none";
             document.getElementById('saspes-categories').style.display = "none";
+            document.getElementById("gt-container").style.display = "none";
+            document.getElementById("scoreTable").style.display = "block";
             gt.setCategoryWeighting(false);
         } else if (opt === "single") {
             document.getElementById('saspes-hypo-assignment').style.display = "block";
             document.getElementById('saspes-categories').style.display = "none";
+            document.getElementById("gt-container").style.display = "none";
+            document.getElementById("scoreTable").style.display = "block";
             gt.setCategoryWeighting(false);
         } else {
-            if (!gt_mounted) {
-                gt_mounted = true;
-                gt.$mount('table.zebra.grid');
-            }
             document.getElementById('saspes-hypo-assignment').style.display = "none";
             document.getElementById('saspes-categories').style.display = "block";
+            document.getElementById("gt-container").style.display = "block";
+            document.getElementById("scoreTable").style.display = "none";
             gt.setCategoryWeighting(true);
         }
     };

--- a/src/js/saspowerschoolff.js
+++ b/src/js/saspowerschoolff.js
@@ -353,12 +353,14 @@ async function getCourses (second_semester, sem1_col, sem2_col) {
                             const page = document.implementation.createHTMLDocument();
                             page.documentElement.innerHTML = response;
                             const sectionId = page.querySelector("div[data-pss-student-assignment-scores]").getAttribute("data-sectionid");
-                            let startDate = currentUrl.searchParams.get("begdate");
-                            startDate = startDate.split("/")[2] + "-" + startDate.split("/")[0] + "-" + startDate.split("/")[1];
-                            let endDate = currentUrl.searchParams.get("enddate");
-                            endDate = endDate.split("/")[2] + "-" + endDate.split("/")[0] + "-" + endDate.split("/")[1];
                             const studentId = page.querySelector("div .xteContentWrapper").getAttribute("data-ng-init").split("\n")[0].split("= '")[1].replace("';", "").substring(3);
-                            const assignment_list = assignmentsFromAPI(studentId, sectionId, startDate, endDate);
+                            let currentSemester;
+                            if (second_semester) {
+                                currentSemester = "S2";
+                            } else {
+                                currentSemester = "S1";
+                            }
+                            const assignment_list = assignmentsFromAPI(studentId, sectionId, currentSemester);
                             courses.push(new Course(temp.trim(), currentUrlString, $course.text(), finalPercent, assignment_list));
                             if (gradeToGPA($course.text()) !== -1) {
                                 new (Vue.extend(ClassGrade))({


### PR DESCRIPTION
This fixes the issue with percentages not showing due to the startDate/endDate not being present in the URL anymore. Now it is using the semester and "storeCode" instead. Once this fix is added, percentages should show and semester GPA should be calculated.

This also fixes an issue with cumulative GPA calculation that might cause double inclusion of the current semester at the end of the semester (the issue did not actually occur for anyone, as the current issue that prevented semester GPA calculation cancelled it out).