### PR TITLE
Fix semester 2 final percent display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saspes",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "SAS Powerschool Enhancement Suite",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
S2 final grade obfuscation is different from S1, so this PR implements the regex for it. Also, S2 final grade display in the guardian home page was never implemented in the first place because I forgot to. Whoops.