### PR TITLE
Create grade override alert & markdown with board text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "saspes",
-  "version": "2.0.0-alpha",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saspes",
-      "version": "2.0.0-alpha",
+      "version": "2.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.5.3",
+        "marked": "^12.0.1",
+        "sanitize-html": "^2.13.0",
         "shepherd.js": "^11.2.0",
         "vite": "^4.5.1",
         "webextension-polyfill": "^0.10.0"
@@ -18,6 +20,7 @@
         "@crxjs/vite-plugin": "^2.0.0-beta.21",
         "@tsconfig/svelte": "^5.0.2",
         "@types/chrome": "^0.0.254",
+        "@types/sanitize-html": "^2.11.0",
         "@types/webextension-polyfill": "^0.10.7",
         "@typescript-eslint/eslint-plugin": "^6.16.0",
         "autoprefixer": "^10.4.16",
@@ -723,6 +726,15 @@
       "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
       "integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
       "dev": true
+    },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.11.0.tgz",
+      "integrity": "sha512-7oxPGNQHXLHE48r/r/qjn7q0hlrs3kL7oZnGj0Wf/h9tj/6ibFyRkNbsDxaBBZ4XUZ0Dx5LGCyDJ04ytSofacQ==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^8.0.0"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -1606,7 +1618,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -1620,7 +1631,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1632,7 +1642,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -1647,7 +1656,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
       "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-      "dev": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -1679,7 +1687,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -1748,8 +1755,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2237,7 +2242,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
       "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -2365,6 +2369,14 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-reference": {
@@ -2518,6 +2530,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.1.tgz",
+      "integrity": "sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mdn-data": {
@@ -2741,6 +2764,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "node_modules/parse5": {
       "version": "7.1.2",
@@ -3230,6 +3258,19 @@
         "graceful-fs": "^4.1.3",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.2"
+      }
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
+      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
       }
     },
     "node_modules/semver": {
@@ -3747,9 +3788,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saspes",
   "private": true,
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "SAS Powerschool Enhancement Suite",
   "type": "module",
   "scripts": {
@@ -18,6 +18,7 @@
     "@crxjs/vite-plugin": "^2.0.0-beta.21",
     "@tsconfig/svelte": "^5.0.2",
     "@types/chrome": "^0.0.254",
+    "@types/sanitize-html": "^2.11.0",
     "@types/webextension-polyfill": "^0.10.7",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "autoprefixer": "^10.4.16",
@@ -33,6 +34,8 @@
   },
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.5.3",
+    "marked": "^12.0.1",
+    "sanitize-html": "^2.13.0",
     "shepherd.js": "^11.2.0",
     "vite": "^4.5.1",
     "webextension-polyfill": "^0.10.0"

--- a/src/content_script/guardianHome/GPA.svelte
+++ b/src/content_script/guardianHome/GPA.svelte
@@ -9,6 +9,8 @@
 
   let editGrades = false;
   let hideGPA = true;
+
+  import Ty from "./TY.svelte";
 </script>
 
 <label class="tw-flex tw-items-center tw-gap-2 tw-mb-2">

--- a/src/content_script/guardianHome/TY.svelte
+++ b/src/content_script/guardianHome/TY.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  let wd: number;
+</script>
+
+<div
+  class="tw-group tw-relative tw-inline-block tw-font-normal tw-pl-2"
+  bind:clientWidth={wd}
+>
+  <button class="tw-ml-0">?</button>
+  <div
+    style:transform="translateX(calc(-100% + {wd}px))"
+    class="tw-pointer-events-none tw-z-50 tw-absolute tw-text-right tw-bg-slate-900 tw-p-1.5 tw-rounded-md tw-text-white tw-left-0 tw-w-max tw-opacity-0 tw-transition-opacity group-hover:tw-opacity-100"
+  >
+    Wow, looks like your teacher manually overrided your calculated grade!<br
+    />This means that your final grade percent does not correspond with your
+    actual final grade letter.
+  </div>
+</div>

--- a/src/content_script/guardianHome/index.ts
+++ b/src/content_script/guardianHome/index.ts
@@ -24,8 +24,9 @@
 
 import { Class, ClassManager } from "../../models/classes";
 import GPA from "./GPA.svelte";
-import { listOfGrades, type Grade } from "../../models/grades";
+import { listOfGrades, type Grade, convertPercentCutoffToGrade } from "../../models/grades";
 import { getFinalPercent } from "../scores/scoresUtilities";
+import Ty from "./TY.svelte";
 
 const classManager = new ClassManager([]);
 
@@ -95,8 +96,12 @@ for (const row of rows) {
 
     finalPercent.then((f) => {
       console.log(f, "S2");
-      if (f !== null)
+      if (f !== null) {
         s2GradeEle.innerHTML += ` (${f.toFixed(2)})`;
+        if (convertPercentCutoffToGrade(f) !== s2Grade) {
+          new Ty({ target: s2GradeEle })
+        }
+      }
     })
   } else {
     console.log("Not finding S2 final percent for ", nameEle, row);

--- a/src/content_script/home/Home.svelte
+++ b/src/content_script/home/Home.svelte
@@ -27,6 +27,9 @@
   import { browserAction } from "webextension-polyfill";
   import browser from "webextension-polyfill";
 
+  import sanitizeHtml from "sanitize-html";
+  import { marked } from "marked";
+
   let board: string | null = null;
 
   onMount(() => {
@@ -40,6 +43,15 @@
       board = "Error while fetching board.";
     }
   });
+
+  let htmlT = "";
+
+  $: if (board) {
+    htmlT = sanitizeHtml(marked.parse(board.split("æ")[1]) as string, {
+      allowedTags: ["b", "p", "i", "em", "strong"],
+      allowedAttributes: {},
+    });
+  }
 </script>
 
 <div class="tw-px-8 tw-py-8 tw-mt-6" id="pes-box">
@@ -77,7 +89,7 @@
     <h3 class="tw-font-medium tw-text-lg">
       Message Board ({board.split("æ")[0]}):
     </h3>
-    <p class="tw-text-sm">{board.split("æ")[1]}</p>
+    <p class="tw-text-sm" id="boardText">{@html htmlT}</p>
   {/if}
   <p class="tw-mt-2">
     Copyright &copy; 2024 Anvay Mathur and the SAS PES Authors
@@ -91,5 +103,9 @@
     -webkit-box-shadow: 0 10px 20px rgba(0, 0, 0, 0.4);
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.4);
     position: relative;
+  }
+
+  :global(#boardText p) {
+    margin-left: 0;
   }
 </style>

--- a/src/models/grades.ts
+++ b/src/models/grades.ts
@@ -80,6 +80,11 @@ export const listOfPercentCutoffs = [
   -2
 ] as const;
 
+/**
+ * Returns the letter grade of a final grade percentage
+ * @param percent final grade percentage
+ * @returns letter grade of final grade percentage
+ */
 export const convertPercentCutoffToGrade = (percent: number): typeof listOfGrades[number] => {
   for (let obj in gradeToPercentCutoff) {
     if (percent >= gradeToPercentCutoff[obj as keyof typeof gradeToPercentCutoff]) {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -9,5 +9,6 @@ module.exports = {
   corePlugins: {
     preflight: false,
   },
-// safelist: process.env.NODE_ENV === 'development' ? [{ pattern: /.+/ }] : [],
+  safelist: process.env.NODE_ENV === 'development' ? [{ pattern: /.+/ }] : [],
 };
+console.log(process.env.NODE_ENV);


### PR DESCRIPTION
Adds a tooltip/popover in the class score detail page next to the grades of classes with overridden grades to explain why the percent is different from the grade.

Also adds markdown support with the board text, which also mitigates sanitization/XSS/MITM vulnerabilities.