### PR TITLE
Modify to support Firefox with Manifest V3

### DIFF
--- a/manifest.config.js
+++ b/manifest.config.js
@@ -51,7 +51,7 @@ export default defineManifest(async (env) => ({
       "resources": ["public/icon.png"]
     }
   ],
-  "background": {
-    "service_worker": "src/background.ts",
-  }
+  "background": process.env.npm_config_firefox
+    ? { "scripts": ["src/background.ts"] }
+    : { "service_worker": "src/background.ts" },
 }))


### PR DESCRIPTION
We will need to create a separate manifest.json file for Chrome and Firefox. Indeed `background` will have a `ChromeManifestBackground | FirefoxManifestBackground | undefined` type so we cannot have both `service_worker` for Chrome and `scripts` for Firefox simultaneously. When we make a Firefox `manifest.json` we can then use `npm run build:dev --firefox`. Seems like this is the only way.