### PR TITLE
Fix CSP issue in Chrome v130

### DIFF
--- a/helpers/postprocess.js
+++ b/helpers/postprocess.js
@@ -1,0 +1,24 @@
+import fs from "fs";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const manifest = require("../dist/manifest.json");
+console.log(manifest.web_accessible_resources);
+
+manifest.web_accessible_resources.forEach((resource, i) => {
+  manifest.web_accessible_resources[i].use_dynamic_url = false;
+  console.log(resource.matches[0])
+  if (resource.matches[0] == "<all_urls>") {
+    manifest.web_accessible_resources[i].matches[0] = "https://powerschool.sas.edu.sg/*";
+  }
+});
+
+console.log(manifest.web_accessible_resources);
+
+
+
+if (fs.existsSync("./dist/manifest.json")) {
+  fs.writeFileSync("./dist/manifest.json", JSON.stringify(manifest, null, 2));
+} else {
+  throw new Error("Manifest file not found");
+}

--- a/helpers/viterunplugin.js
+++ b/helpers/viterunplugin.js
@@ -1,0 +1,128 @@
+// From https://github.com/pnd280/complexity/blob/alpha/vite-plugins/vite-plugin-run-command-on-demand.ts
+
+import chalk from "chalk";
+import { exec } from "child_process";
+
+
+const pluginName = "vite-plugin-run-command-on-demand";
+
+/**
+ * Logs a message with the plugin name.
+ * @param {string} message - The message to log.
+ */
+const log = (message) => console.log(chalk.blue(`\n[${pluginName}]`), message);
+
+/**
+ * Logs an error message with the plugin name.
+ * @param {string} message - The error message to log.
+ */
+const logError = (message) =>
+  console.error(chalk.blue(`\n[${pluginName}]`), chalk.red(message), "\n");
+
+/**
+ * Runs a shell command.
+ * @param {string} command - The command to run.
+ * @returns {Promise<void>} A promise that resolves when the command completes.
+ */
+const runCommand = (command) =>
+  new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        logError(`Error executing command: ${command}\n${stderr}`);
+        reject(error);
+      } else {
+        log(`Command executed successfully: ${command}\n${stdout}`);
+        resolve();
+      }
+    });
+  });
+
+/**
+ * @typedef {Object} CustomCommandsPluginOptions
+ * @property {string} [beforeServerStart] - Command to run before the server starts.
+ * @property {string} [afterServerStart] - Command to run after the server starts.
+ * @property {string} [onHotUpdate] - Command to run on hot update.
+ * @property {string} [beforeBuild] - Command to run before the build starts.
+ * @property {string} [afterBuild] - Command to run after the build ends.
+ * @property {string} [closeBundle] - Command to run when the bundle is closed.
+ */
+
+/**
+ * Executes a command if it is defined.
+ * @param {string|undefined} command - The command to execute.
+ * @param {string} errorMessage - The error message to log if the command fails.
+ */
+const executeCommand = async (command, errorMessage) => {
+  if (command) {
+    try {
+      await runCommand(command);
+    } catch {
+      logError(errorMessage);
+    }
+  }
+};
+
+/**
+ * Checks if the current environment is allowed.
+ * @returns {boolean} True if the environment is "development" or "production".
+ */
+const isAllowedEnvironment = () => {
+  const env = process.env.NODE_ENV;
+  return env === "development" || env === "production";
+};
+
+/**
+ * Vite plugin to run custom commands on demand.
+ * @param {CustomCommandsPluginOptions} [options={}] - The plugin options.
+
+ */
+export default function customCommandsPlugin(options = {}) {
+  return {
+    name: pluginName,
+    configureServer(server) {
+      if (!isAllowedEnvironment()) return;
+      server.httpServer?.once("listening", async () => {
+        await executeCommand(
+          options.beforeServerStart,
+          `Error running beforeServerStart command: ${options.beforeServerStart}`
+        );
+        await executeCommand(
+          options.afterServerStart,
+          `Error running afterServerStart command: ${options.afterServerStart}`
+        );
+      });
+    },
+    async handleHotUpdate(ctx) {
+      if (!isAllowedEnvironment()) return ctx.modules;
+      const isPageReload = ctx.modules.some((module) => !module.isSelfAccepting);
+      if (!isPageReload) {
+        await executeCommand(
+          options.onHotUpdate,
+          `Error running onHotUpdate command: ${options.onHotUpdate}`
+        );
+      }
+      return ctx.modules;
+    },
+    async buildStart() {
+      if (!isAllowedEnvironment()) return;
+      await executeCommand(
+        options.beforeBuild,
+        `Error running beforeBuild command: ${options.beforeBuild}`
+      );
+    },
+    async buildEnd() {
+      if (!isAllowedEnvironment()) return;
+      await executeCommand(
+        options.afterBuild,
+        `Error running afterBuild command: ${options.afterBuild}`
+      );
+    },
+    async closeBundle() {
+      if (!isAllowedEnvironment()) return;
+      await executeCommand(
+        options.closeBundle,
+        `Error running closeBundle command: ${options.closeBundle}`
+      );
+    },
+  };
+}

--- a/manifest.config.js
+++ b/manifest.config.js
@@ -1,6 +1,6 @@
-import { defineManifest } from '@crxjs/vite-plugin'
-import packageJson from './package.json'
-import 'dotenv/config'
+import { defineManifest } from '@crxjs/vite-plugin';
+import 'dotenv/config';
+import packageJson from './package.json';
 const { version } = packageJson
 
 
@@ -20,7 +20,8 @@ export default defineManifest(async (env) => ({
   "content_scripts": [
     {
       "matches": ["https://powerschool.sas.edu.sg/guardian/scores.html*"],
-      "js": ["src/content_script/scores/index.ts"]
+      "js": ["src/content_script/scores/index.ts"],
+
     },
     {
       "matches": ["https://powerschool.sas.edu.sg/*"],
@@ -48,8 +49,9 @@ export default defineManifest(async (env) => ({
   "web_accessible_resources": [
     {
       "matches": ["https://powerschool.sas.edu.sg/*"],
-      "resources": ["public/icon.png"]
-    }
+      "resources": ["public/icon.png"],
+      "use_dynamic_url": false
+    },
   ],
   "background": {
     "service_worker": "src/background.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "saspes",
-  "version": "2.0.0-alpha",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saspes",
-      "version": "2.0.0-alpha",
+      "version": "2.0.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.5.3",
+        "chalk": "^5.3.0",
         "shepherd.js": "^11.2.0",
         "vite": "^4.5.1",
         "webextension-polyfill": "^0.10.0"
@@ -55,39 +56,26 @@
       }
     },
     "node_modules/@crxjs/vite-plugin": {
-      "version": "2.0.0-beta.21",
-      "resolved": "https://registry.npmjs.org/@crxjs/vite-plugin/-/vite-plugin-2.0.0-beta.21.tgz",
-      "integrity": "sha512-kSXgHHqCXASqJ8NmY94+KLGVwdtkJ0E7KsRQ+vbMpRliJ5ze0xnSk0l41p4txlUysmEoqaeo4Xb7rEFdcU2zjQ==",
+      "version": "2.0.0-beta.28",
+      "resolved": "https://registry.npmjs.org/@crxjs/vite-plugin/-/vite-plugin-2.0.0-beta.28.tgz",
+      "integrity": "sha512-JUoB1431PvruQqVpxvJ5j6qh0NNx5sXafAXo+VltORtJQrS6wprI5QK4k6PLKV+WacsFuPLveM2ydBCEopU49w==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.1.2",
         "@webcomponents/custom-elements": "^1.5.0",
         "acorn-walk": "^8.2.0",
         "cheerio": "^1.0.0-rc.10",
-        "connect-injector": "^0.4.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.3.3",
         "es-module-lexer": "^0.10.0",
         "fast-glob": "^3.2.11",
         "fs-extra": "^10.0.1",
         "jsesc": "^3.0.2",
-        "magic-string": "^0.26.0",
+        "magic-string": "^0.30.12",
         "picocolors": "^1.0.0",
         "react-refresh": "^0.13.0",
-        "rollup": "2.78.1",
+        "rollup": "2.79.2",
         "rxjs": "7.5.7"
-      }
-    },
-    "node_modules/@crxjs/vite-plugin/node_modules/magic-string": {
-      "version": "0.26.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -566,9 +554,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.20",
@@ -1043,6 +1031,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -1124,11 +1128,11 @@
       }
     },
     "node_modules/axobject-query": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
-      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
-      "dependencies": {
-        "dequal": "^2.0.3"
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/balanced-match": {
@@ -1163,12 +1167,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1254,36 +1258,14 @@
       ]
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/cheerio": {
@@ -1386,36 +1368,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
-    },
-    "node_modules/connect-injector": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/connect-injector/-/connect-injector-0.4.4.tgz",
-      "integrity": "sha512-hdBG8nXop42y2gWCqOV8y1O3uVk4cIU+SoxLCPyCUKRImyPiScoNiSulpHjoktRU1BdI0UzoUdxUa87thrcmHw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.0.0",
-        "q": "^1.0.1",
-        "stream-buffers": "^0.2.3",
-        "uberproto": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/connect-injector/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/connect-injector/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "node_modules/convert-source-map": {
@@ -1852,6 +1804,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2010,9 +1979,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2510,14 +2479,11 @@
       "peer": true
     },
     "node_modules/magic-string": {
-      "version": "0.30.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "version": "0.30.12",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/mdn-data": {
@@ -2535,12 +2501,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -3041,16 +3007,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3162,9 +3118,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3330,22 +3286,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true
-    },
-    "node_modules/stream-buffers": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.6.tgz",
-      "integrity": "sha512-ZRpmWyuCdg0TtNKk8bEqvm13oQvXMmzXDsfD4cBgcx5LouborvU5pm3JMkdTP3HcszyUI08AM1dHMXA5r2g6Sg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.3.0"
-      }
-    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -3397,16 +3337,17 @@
       }
     },
     "node_modules/svelte": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.8.tgz",
-      "integrity": "sha512-hU6dh1MPl8gh6klQZwK/n73GiAHiR95IkFsesLPbMeEZi36ydaXL/ZAb4g9sayT0MXzpxyZjR28yderJHxcmYA==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.19.tgz",
+      "integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/estree": "^1.0.1",
         "acorn": "^8.9.0",
         "aria-query": "^5.3.0",
-        "axobject-query": "^3.2.1",
+        "axobject-query": "^4.0.0",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
         "estree-walker": "^3.0.3",
@@ -3682,15 +3623,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uberproto": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/uberproto/-/uberproto-1.2.0.tgz",
-      "integrity": "sha512-pGtPAQmLwh+R9w81WVHzui1FfedpQWQpiaIIfPCwhtsBez4q6DYbJFfyXPVHPUTNFnedAvNEnkoFiLuhXIR94w==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -3747,9 +3679,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
+      "integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -3801,9 +3733,9 @@
       }
     },
     "node_modules/vite/node_modules/rollup": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saspes",
   "private": true,
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "SAS Powerschool Enhancement Suite",
   "type": "module",
   "scripts": {
@@ -15,7 +15,7 @@
   "author": "Anvay Mathur and SAS PES Contributors",
   "license": "AGPL-3.0-only",
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.21",
+    "@crxjs/vite-plugin": "^2.0.0-beta.28",
     "@tsconfig/svelte": "^5.0.2",
     "@types/chrome": "^0.0.254",
     "@types/webextension-polyfill": "^0.10.7",
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.5.3",
+    "chalk": "^5.3.0",
     "shepherd.js": "^11.2.0",
     "vite": "^4.5.1",
     "webextension-polyfill": "^0.10.0"

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -9,3 +9,4 @@
     <script type="module" src="./index.ts"></script>
   </body>
 </html>
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,12 +22,13 @@
  *
  */
 import { crx } from "@crxjs/vite-plugin";
-import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import 'dotenv/config';
+import { defineConfig } from "vite";
 import manifest, { realVersion } from "./manifest.config.js";
 import pkg from "./package.json";
-import 'dotenv/config'
 
+// import vitePluginRunCommandOnDemand from "./helpers/viterunplugin.js";
 
 
 export default defineConfig({
@@ -36,6 +37,7 @@ export default defineConfig({
     crx({
       manifest: manifest()
     }),
+
   ],
   define: {
     SAS_PES_VERSION: `"${process.argv[4] === "production" ? pkg.version : `${pkg.version} Development Build ${realVersion}`}"`,


### PR DESCRIPTION
Recently, Chrome pushed out v130 which enabled a feature known as `use_dynamic_url` within `web_accessible_resources` in the manifest file. By default, the version of CRX.js I was using set `use_dynamic_url` to true for all the files SASPES needs to work. However, this feature was implemented wrong (see [this bug report](https://issues.chromium.org/issues/363027634?pli=1)) and prevents any JavaScript files from being loaded. This prevents the extension itself from loading, which is why many users may have noticed the extension just disappeared. I have updated CRX.js to the latest version, which sets `use_dynamic_url` to false which prevents this bug. Chrome has also fixed this bug and it will be included in later updates soon.

AFAIK, this bug has existed since early-October, but because I tend to ignore the big red button warning me to update Chrome, I did not observe it until now. This was reported to me only this morning, so I would like to apologize to everyone who were inconvenienced by this bug. 